### PR TITLE
Teach Healing Potion Fix

### DIFF
--- a/Data/Scripts/Content/Story/Dialoge/DIA_VLK_417_Constantino.d
+++ b/Data/Scripts/Content/Story/Dialoge/DIA_VLK_417_Constantino.d
@@ -1050,11 +1050,11 @@ func void DIA_Constantino_Teach_BACK()
 
 func void DIA_Constantino_TEACH_Health01()
 {
-/*	if (B_TeachPlayerTalentAlchemy(self, other, POTION_Health_01))
+	if (B_TeachPlayerTalentAlchemy(self, other, POTION_Health_01))
 	{
-		AI_Output(self, other, "DIA_Constantino_TEACH_Health01_10_00"); //The ingredients for an essence of healing are healing plants and meadow knotweed.
+		//AI_Output(self, other, "DIA_Constantino_TEACH_Health01_10_00"); //The ingredients for an essence of healing are healing plants and meadow knotweed.
 	};
-*/
+
 
 	Info_ClearChoices(DIA_Constantino_Teach);
 };


### PR DESCRIPTION
- Fixed an issue where selecting option to learn Essence of Healing at Constantino would bring you back to the root of his dialogue tree without teaching you the potion;