### PR TITLE
Maximum Mana for Teachers

### DIFF
--- a/Data/Scripts/Content/Story/Dialoge/DIA_Addon_KDW_14050_Merdarion_ADW.d
+++ b/Data/Scripts/Content/Story/Dialoge/DIA_Addon_KDW_14050_Merdarion_ADW.d
@@ -371,7 +371,7 @@ func void DIA_Addon_Merdarion_ADW_TEACH_MANA_Info()
 
 func void DIA_Addon_Merdarion_ADW_TEACH_MANA_BACK()
 {
-	if (other.attribute[ATR_MANA_MAX] >= T_HIGH)
+	if (other.attribute[ATR_MANA_MAX] >= Mana_Med)
 	{
 		AI_Output(self, other, "DIA_Addon_Merdarion_ADW_TEACH_MANA_06_00"); //Your request goes beyond my capabilities.
 		AI_Output(self, other, "DIA_Addon_Merdarion_ADW_TEACH_MANA_06_01"); //I cannot teach you anything more.
@@ -383,7 +383,7 @@ func void DIA_Addon_Merdarion_ADW_TEACH_MANA_BACK()
 
 func void DIA_Addon_Merdarion_ADW_TEACH_MANA_1()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, T_HIGH);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, Mana_Med);
 
 	Info_ClearChoices(DIA_Addon_Merdarion_ADW_TEACH_MANA);
 	Info_AddChoice(DIA_Addon_Merdarion_ADW_TEACH_MANA, DIALOG_BACK, DIA_Addon_Merdarion_ADW_TEACH_MANA_BACK);
@@ -393,7 +393,7 @@ func void DIA_Addon_Merdarion_ADW_TEACH_MANA_1()
 
 func void DIA_Addon_Merdarion_ADW_TEACH_MANA_5()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, T_HIGH);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, Mana_Med);
 
 	Info_ClearChoices(DIA_Addon_Merdarion_ADW_TEACH_MANA);
 	Info_AddChoice(DIA_Addon_Merdarion_ADW_TEACH_MANA, DIALOG_BACK, DIA_Addon_Merdarion_ADW_TEACH_MANA_BACK);

--- a/Data/Scripts/Content/Story/Dialoge/DIA_KDF_504_Parlan.d
+++ b/Data/Scripts/Content/Story/Dialoge/DIA_KDF_504_Parlan.d
@@ -863,7 +863,7 @@ func void DIA_Parlan_TEACH_MANA_Info()
 
 func void DIA_Parlan_TEACH_MANA_BACK()
 {
-	if (other.attribute[ATR_MANA_MAX] >= T_MED)
+	if (other.attribute[ATR_MANA_MAX] >= Mana_MED)
 	{
 		AI_Output(self, other, "DIA_Parlan_TEACH_MANA_05_00"); //Your magic power has grown. I cannot help you to increase it more.
 		AI_Output(self, other, "DIA_Parlan_TEACH_MANA_05_01"); //If you want to learn more, ask Pyrokar.
@@ -875,7 +875,7 @@ func void DIA_Parlan_TEACH_MANA_BACK()
 
 func void DIA_Parlan_TEACH_MANA_1()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, T_MED);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, Mana_MED);
 
 	Info_ClearChoices(DIA_Parlan_TEACH_MANA);
 	Info_AddChoice(DIA_Parlan_TEACH_MANA, DIALOG_BACK, DIA_Parlan_TEACH_MANA_BACK);
@@ -885,7 +885,7 @@ func void DIA_Parlan_TEACH_MANA_1()
 
 func void DIA_Parlan_TEACH_MANA_5()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, T_MED);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, Mana_MED);
 
 	Info_ClearChoices(DIA_Parlan_TEACH_MANA);
 	Info_AddChoice(DIA_Parlan_TEACH_MANA, DIALOG_BACK, DIA_Parlan_TEACH_MANA_BACK);

--- a/Data/Scripts/Content/Story/Dialoge/DIA_PC_Mage_NW.d
+++ b/Data/Scripts/Content/Story/Dialoge/DIA_PC_Mage_NW.d
@@ -820,7 +820,7 @@ func void DIA_MiltenNW_Mana_Info()
 
 func void DIA_MiltenNW_Mana_BACK()
 {
-	if (other.attribute[ATR_MANA_MAX] >= T_MED)
+	if (other.attribute[ATR_MANA_MAX] >= Mana_Low)
 	{
 		AI_Output(self, other, "DIA_MiltenNW_Mana_03_00"); //Your magic power is great. Too great for me to be able to help you increase it.
 	};
@@ -830,7 +830,7 @@ func void DIA_MiltenNW_Mana_BACK()
 
 func void DIA_MiltenNW_Mana_1()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, T_MED);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, Mana_Low);
 
 	Info_ClearChoices(DIA_MiltenNW_Mana);
 
@@ -841,7 +841,7 @@ func void DIA_MiltenNW_Mana_1()
 
 func void DIA_MiltenNW_Mana_5()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, T_MED);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, Mana_Low);
 
 	Info_ClearChoices(DIA_MiltenNW_Mana);
 

--- a/Data/Scripts/Content/Story/Dialoge/DIA_PC_Mage_OW.d
+++ b/Data/Scripts/Content/Story/Dialoge/DIA_PC_Mage_OW.d
@@ -561,7 +561,7 @@ func void DIA_MiltenOW_Mana_Info()
 
 func void DIA_MiltenOW_Mana_BACK()
 {
-	if (other.attribute[ATR_MANA_MAX] >= T_MED)
+	if (other.attribute[ATR_MANA_MAX] >= Mana_Low)
 	{
 		AI_Output(self, other, "DIA_MiltenOW_Mana_03_00"); //Your magic power is great. Too great for me to be able to help you to increase it.
 	};
@@ -571,7 +571,7 @@ func void DIA_MiltenOW_Mana_BACK()
 
 func void DIA_MiltenOW_Mana_1()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, T_MED);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, Mana_Low);
 
 	Info_ClearChoices(DIA_MiltenOW_Mana);
 
@@ -582,7 +582,7 @@ func void DIA_MiltenOW_Mana_1()
 
 func void DIA_MiltenOW_Mana_5()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, T_MED);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, Mana_Low);
 
 	Info_ClearChoices(DIA_MiltenOW_Mana);
 

--- a/Data/Scripts/Content/Story/Dialoge/DIA_VLK_439_Vatras.d
+++ b/Data/Scripts/Content/Story/Dialoge/DIA_VLK_439_Vatras.d
@@ -1786,7 +1786,7 @@ func void DIA_Vatras_Teach_Info()
 
 func void DIA_Vatras_Teach_BACK()
 {
-	if (other.attribute[ATR_MANA_MAX] >= T_HIGH)
+	if (other.attribute[ATR_MANA_MAX] >= Mana_MED)
 	{
 		AI_Output(self, other, "DIA_Vatras_Teach_05_00"); //Your magical power has grown beyond my ability to teach you.
 	};
@@ -1796,7 +1796,7 @@ func void DIA_Vatras_Teach_BACK()
 
 func void DIA_Vatras_Teach_1()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, T_HIGH);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 1, Mana_MED);
 
 	Info_ClearChoices(DIA_Vatras_Teach);
 
@@ -1807,7 +1807,7 @@ func void DIA_Vatras_Teach_1()
 
 func void DIA_Vatras_Teach_5()
 {
-	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, T_HIGH);
+	B_TeachAttributePoints(self, other, ATR_MANA_MAX, 5, Mana_MED);
 
 	Info_ClearChoices(DIA_Vatras_Teach);
 

--- a/Data/Scripts/Content/Story/Story_Globals.d
+++ b/Data/Scripts/Content/Story/Story_Globals.d
@@ -9,6 +9,9 @@ const int T_HIGH = 120;
 const int T_MED = 90;
 const int T_LOW = 60;
 
+const int Mana_LOW = 200;
+const int Mana_MED = 300;
+
 
 var int GMM_Summon_Time;
 


### PR DESCRIPTION
Increased a maximum of mana teachers can teach:
- Parlan from 90 to 300
- Merdarion from 120 to 300
- Milten from 90 to 200 (He still teaches up to 500 on Irdorath as done in previous updates)
- Vatras from 120 to 300